### PR TITLE
feat(bashrc): modularization of shell init scripts [TECH-6]

### DIFF
--- a/roles/developer/tasks/main.yml
+++ b/roles/developer/tasks/main.yml
@@ -3,8 +3,14 @@
 - name: set facts for use later
   include_tasks: tools/set_facts.yml
 
-- name: create bash_profile
-  include_tasks: tools/bash_profile.yml
+- name: create bashrcd
+  include_tasks: tools/bashrcd.yml
+
+- name: set shell env var
+  include_tasks: tools/shell_env_var.yml
+
+- name: set ssh agent
+  include_tasks: tools/ssh_agent.yml
 
 - name: install terraform
   include_tasks: tools/terraform.yml

--- a/roles/developer/tasks/tools/bash_profile.yml
+++ b/roles/developer/tasks/tools/bash_profile.yml
@@ -1,9 +1,0 @@
----
-
-- name: ensure .bash_profile exists
-  ansible.builtin.copy:
-    content: ""
-    dest: "/home/{{ lookup('env', 'USER') }}/.bash_profile"
-    mode: "0640"
-    force: no
-    owner: "{{ lookup('env', 'USER') }}"

--- a/roles/developer/tasks/tools/bashrcd.yml
+++ b/roles/developer/tasks/tools/bashrcd.yml
@@ -1,0 +1,20 @@
+---
+
+- name: add bashrc.d directory feature
+  ansible.builtin.blockinfile:
+    path:  "/etc/bash.bashrc"
+    block: |
+      # Taken from https://github.com/Groupe-Hevea/puppet-config/blob/master/modules/bash/templates/bashrc.erb
+      # Load user's .bash.rc.d/
+      if [ -d ~/.bashrc.d ]; then
+        for file in ~/.bashrc.d/*.bashrc; do
+          [ -e "$file" ] || continue
+          source "$file"
+        done
+      fi
+
+- name: ensure bashrc.d exists
+  ansible.builtin.file:
+    path: "/home/{{ lookup('env', 'USER') }}/.bashrc.d"
+    state: directory
+    mode: '0755'

--- a/roles/developer/tasks/tools/docker.yml
+++ b/roles/developer/tasks/tools/docker.yml
@@ -65,12 +65,14 @@
 ## Start docker at startup :
 # Windows 10
 - name: Start docker at startup - Windows 10
-  ansible.builtin.blockinfile:
-    path: "/home/{{ lookup('env', 'USER') }}/.bash_profile"
-    block: |
-      #Start docker at startup
+  ansible.builtin.copy:
+    content: |
+      # Start docker at startup
       wsl.exe -u root -e sh -c "service docker status || service docker start"
-    state: present
+    dest: "/home/{{ lookup('env', 'USER') }}/.bashrc.d/docker_startup.bashrc"
+    mode: '0644'
+    owner: "{{ lookup('env', 'USER') }}"
+    group: "{{ lookup('env', 'USER') }}"
   when: winver == "10"
 
 # Windows 11
@@ -93,10 +95,7 @@
   when: winver == "11"
 
 - name: Delete old startup for Windows 10 - Windows 11
-  ansible.builtin.blockinfile:
-    path: "/home/{{ lookup('env', 'USER') }}/.bash_profile"
-    block: |
-      #Start docker at startup
-      wsl.exe -u root -e sh -c "service docker status || service docker start"
+  ansible.builtin.file:
+    path: "/home/{{ lookup('env', 'USER') }}/.bashrc.d/docker_startup.bashrc"
     state: absent
   when: winver == "11"

--- a/roles/developer/tasks/tools/shell_env_var.yml
+++ b/roles/developer/tasks/tools/shell_env_var.yml
@@ -1,0 +1,12 @@
+---
+
+- name: define shell env var
+  ansible.builtin.copy:
+    content: |
+      # Define shell env var
+      export UID
+      export GID="$(id -g $(whoami))"
+    dest: "/home/{{ lookup('env', 'USER') }}/.bashrc.d/shell_env_var.bashrc"
+    mode: '0644'
+    owner: "{{ lookup('env', 'USER') }}"
+    group: "{{ lookup('env', 'USER') }}"

--- a/roles/developer/tasks/tools/ssh_agent.yml
+++ b/roles/developer/tasks/tools/ssh_agent.yml
@@ -3,16 +3,14 @@
 - name: enable ssh agent
   ansible.builtin.copy:
     content: |
-      # Taken from https://github.com/Groupe-Hevea/puppet-config/blob/master/modules/account/templates/ssh-agent.bashrc.erb
       # Enable ssh agent
-      ssh-add -l &>/dev/null
-      if [[ "$?" == 2 ]]; then
-        eval $(ssh-agent) >/dev/null
-      fi
-
-      ssh-add -l &>/dev/null
-      if [[ "$?" == 1 ]]; then
-        ssh-add ~/.ssh/id_rsa &>/dev/null
+      if [ -z "$(pgrep ssh-agent)" ]; then
+        rm -rf /tmp/ssh-*
+        eval $(ssh-agent -s)
+        ssh-add
+      else
+        export SSH_AGENT_PID=$(pgrep ssh-agent)
+        export SSH_AUTH_SOCK=$(find /tmp/ssh-* -name agent.*)
       fi
     dest: "/home/{{ lookup('env', 'USER') }}/.bashrc.d/ssh_agent.bashrc"
     mode: '0644'

--- a/roles/developer/tasks/tools/ssh_agent.yml
+++ b/roles/developer/tasks/tools/ssh_agent.yml
@@ -1,0 +1,20 @@
+---
+
+- name: enable ssh agent
+  ansible.builtin.copy:
+    content: |
+      # Taken from https://github.com/Groupe-Hevea/puppet-config/blob/master/modules/account/templates/ssh-agent.bashrc.erb
+      # Enable ssh agent
+      ssh-add -l &>/dev/null
+      if [[ "$?" == 2 ]]; then
+        eval $(ssh-agent) >/dev/null
+      fi
+
+      ssh-add -l &>/dev/null
+      if [[ "$?" == 1 ]]; then
+        ssh-add ~/.ssh/id_rsa &>/dev/null
+      fi
+    dest: "/home/{{ lookup('env', 'USER') }}/.bashrc.d/ssh_agent.bashrc"
+    mode: '0644'
+    owner: "{{ lookup('env', 'USER') }}"
+    group: "{{ lookup('env', 'USER') }}"


### PR DESCRIPTION
- modularize shell init script (bashrc)
- fix bashrc file ignored: if bash_profile exists it is loaded but bashrc is not loaded if not specified in bash_profile. Without bash_profile, bashrc is loaded.
- add ssh agent init script
- define UID & GID env var