### PR TITLE
fix(gpg): add keys for repositories as prerequisites

### DIFF
--- a/roles/developer/tasks/main.yml
+++ b/roles/developer/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- name: Ensure apt_keys are present before actions
+  ansible.builtin.include_tasks: tools/00_apt_keys.yml
 
 - name: set facts for use later
   include_tasks: tools/set_facts.yml

--- a/roles/developer/tasks/tools/00_apt_keys.yml
+++ b/roles/developer/tasks/tools/00_apt_keys.yml
@@ -1,0 +1,14 @@
+- name: add github cli apt key
+  apt_key:
+    url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+    state: present
+
+- name: add hashicorp apt key
+  apt_key:
+    url: https://apt.releases.hashicorp.com/gpg
+    state: present
+
+- name: add docker apt key
+  apt_key:
+    url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
+    state: present

--- a/roles/developer/tasks/tools/docker.yml
+++ b/roles/developer/tasks/tools/docker.yml
@@ -12,11 +12,6 @@
     state: present
     update_cache: yes
 
-- name: add docker apt fingerprint
-  apt_key:
-    url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
-    state: present
-
 - name: add docker apt repository
   apt_repository:
     repo: "deb [arch=amd64] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"

--- a/roles/developer/tasks/tools/gh_cli.yml
+++ b/roles/developer/tasks/tools/gh_cli.yml
@@ -5,11 +5,6 @@
 # sudo apt update
 # sudo apt install gh
 
-- name: add github cli apt key
-  apt_key:
-    url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
-    state: present
-
 - name: add github cli apt repository
   apt_repository:
     repo: deb [arch=amd64] https://cli.github.com/packages stable main

--- a/roles/developer/tasks/tools/terraform.yml
+++ b/roles/developer/tasks/tools/terraform.yml
@@ -9,10 +9,6 @@
     state: latest
     update_cache: yes
 
-- name: add hashicorp apt key
-  apt_key:
-    url: https://apt.releases.hashicorp.com/gpg
-    state: present
 
 - name: add hashicorp apt repository
   apt_repository:


### PR DESCRIPTION
Add apt keys for repo before all actions to avoid error on early apt update