### PR TITLE
feat(tool): add aqua cli package manager

### DIFF
--- a/configure.yml
+++ b/configure.yml
@@ -5,9 +5,11 @@
   become: yes
   vars:
     docker_users: ["{{ lookup('env', 'USER') }}"]
-  vars_prompt:
-    - name: github_token
-      prompt: What is your github_token?
-      private: false
+    github_token: "{{ lookup('env', 'GITHUB_TOKEN') }}"
+  pre_tasks:
+    - name: ensure GITHUB_TOKEN is provided
+      ansible.builtin.fail:
+        msg: "environment variable is not defined. Please use export GITHUB_TOKEN=<token> and rerun the playbook"
+      when: github_token == ''
   roles:
     - developer

--- a/roles/developer/tasks/main.yml
+++ b/roles/developer/tasks/main.yml
@@ -17,5 +17,8 @@
 - name: install gh cli
   include_tasks: tools/gh_cli.yml
 
+- name: install aqua cli
+  ansible.builtin.include_tasks: tools/aqua_cli.yml
+
 - name: install lastpass-cli
   include_tasks: tools/lastpass-cli.yml

--- a/roles/developer/tasks/tools/aqua_cli.yml
+++ b/roles/developer/tasks/tools/aqua_cli.yml
@@ -1,0 +1,50 @@
+---
+- name: Check if aqua is installed
+  ansible.builtin.stat:
+    path: "{{ AQUA_INSTALL_PATH }}/aqua"
+  register: aqua_installed
+
+- name: Get latest aqua version
+  ansible.builtin.uri:
+    url: "https://api.github.com/repos/aquaproj/aqua/releases/latest"
+    return_content: yes
+    status_code: 200
+  register: aqua_latest_version
+  changed_when: false
+
+- name: Verify current version of aqua
+  ansible.builtin.shell: "{{ AQUA_INSTALL_PATH }}/aqua version"
+  register: aqua_version
+  when: aqua_installed.stat.exists
+  changed_when: false
+
+- name: Block Ensure aqua is installed
+  block:
+  - name: Download aqua
+    ansible.builtin.get_url:
+      url: "https://github.com/aquaproj/aqua/releases/download/{{ aqua_latest_version.json.tag_name }}/aqua_linux_{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' if ansible_architecture == 'aarch64' else ansible_architecture }}.tar.gz"
+      dest: /tmp/aqua.tar.gz
+
+  - name: Extract aqua
+    ansible.builtin.unarchive:
+      src: /tmp/aqua.tar.gz
+      dest: /tmp
+      remote_src: true
+
+  - name: Install aqua
+    become: true
+    ansible.builtin.copy:
+      src: /tmp/aqua
+      dest: "{{ AQUA_INSTALL_PATH }}/aqua"
+      mode: 0755
+      remote_src: true
+
+  - name: Remove aqua temp files
+    ansible.builtin.file:
+      path: /tmp/aqua.tar.gz
+      state: absent
+    loop:
+      - /tmp/aqua
+      - /tmp/aqua.tar.gz
+
+  when: (not aqua_installed.stat.exists) or ( (aqua_latest_version.json.tag_name | regex_replace('^v(.*)$', '\\1') ) not in aqua_version.stdout)

--- a/roles/developer/tasks/user-env/shell_env.yml
+++ b/roles/developer/tasks/user-env/shell_env.yml
@@ -32,6 +32,7 @@
       export GID="$(id -g $(whoami))"
       export GITHUB_TOKEN={{ github_token }}
       export COMPOSER_AUTH="{\"github-oauth\": {\"github.com\": \"$GITHUB_TOKEN\"}}"
+      export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"
     dest: "/home/{{ lookup('env', 'USER') }}/.rc.d/98-shell_env_vars.sh"
     mode: '0644'
     owner: "{{ lookup('env', 'USER') }}"

--- a/roles/developer/vars/main.yml
+++ b/roles/developer/vars/main.yml
@@ -1,0 +1,1 @@
+AQUA_INSTALL_PATH: /usr/local/bin


### PR DESCRIPTION
Add [aqua cli](https://aquaproj.github.io/) to wsl.
This tool permit to manage tools and theirs versions for each repo where aqua.yaml file is declared.
So we can permit to declare tools needed on a repo and onboard easily users on it.